### PR TITLE
OpenXR: Add method to pass a see through layer

### DIFF
--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
@@ -61,6 +61,8 @@ namespace Stride.VirtualReality
         // array of view_count containers for submitting swapchains with rendered VR frames
         CompositionLayerProjectionView[] projection_views;
         View[] views;
+        private unsafe CompositionLayerBaseHeader* [] compositionLayers = new CompositionLayerBaseHeader* [2];
+        private uint nextCompositionLayer = 0;
 
         public override Size2 ActualRenderFrameSize
         {
@@ -617,6 +619,16 @@ namespace Stride.VirtualReality
         }
 #endif
 
+
+        public unsafe void SetPassthroughLayer(IntPtr layer)
+        {
+            if (layer != IntPtr.Zero)
+            {
+                this.compositionLayers[0] = (CompositionLayerBaseHeader*)layer;
+                nextCompositionLayer = 1;
+            }
+        }
+
         public override void Commit(CommandList commandList, Texture renderFrame)
         {
             // if we didn't wait a frame, don't commit
@@ -649,23 +661,28 @@ namespace Stride.VirtualReality
 
                 unsafe
                 {
+                CompositionLayerProjection projectionLayer;
                 fixed (CompositionLayerProjectionView* projection_views_ptr = &projection_views[0])
                 {
-                    var projectionLayer = new CompositionLayerProjection
+                    projectionLayer = new CompositionLayerProjection
                     (
                         viewCount: (uint)projection_views.Length,
                         views: projection_views_ptr,
                         space: globalPlaySpace
                     );
 
-                    var layerPointer = (CompositionLayerBaseHeader*)&projectionLayer;
+                compositionLayers[nextCompositionLayer] = (CompositionLayerBaseHeader*)&projectionLayer;
+                nextCompositionLayer += 1;
+                fixed (CompositionLayerBaseHeader** compositionLayersPtr = &compositionLayers[0])
+                {
+                    var projectionLayerPtr = (CompositionLayerBaseHeader*)&projectionLayer;
                     var frameEndInfo = new FrameEndInfo()
                     {
                         Type = StructureType.TypeFrameEndInfo,
                         DisplayTime = globalFrameState.PredictedDisplayTime,
                         EnvironmentBlendMode = EnvironmentBlendMode.Opaque,
-                        LayerCount = 1,
-                        Layers = &layerPointer,
+                        LayerCount = nextCompositionLayer,
+                        Layers = compositionLayersPtr,
                         Next = null,
                     };
 

--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
@@ -484,6 +484,7 @@ namespace Stride.VirtualReality
                 Next = null,
             };
             Xr.StringToPath(Instance, "/user/hand/left", ref leftHandPath);
+            nextCompositionLayer = 0;
         }
 
         private void EndNullFrame()
@@ -505,6 +506,7 @@ namespace Stride.VirtualReality
             if (!runFramecycle || !sessionRunning)
             {
                 begunFrame = false;
+                nextCompositionLayer = 0;
                 return;
             }
 
@@ -543,6 +545,7 @@ namespace Stride.VirtualReality
                 EndNullFrame();
                 begunFrame = false;
             }
+            nextCompositionLayer = 0;
         }
 
         public void UpdateViews()
@@ -632,8 +635,10 @@ namespace Stride.VirtualReality
         public override void Commit(CommandList commandList, Texture renderFrame)
         {
             // if we didn't wait a frame, don't commit
-            if (begunFrame == false)
+            if (begunFrame == false) {
+                nextCompositionLayer = 0;
                 return;
+            }
 
             begunFrame = false;
 
@@ -694,6 +699,7 @@ namespace Stride.VirtualReality
             {
                 EndNullFrame();
             }
+            nextCompositionLayer = 0;
         }
 
 

--- a/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
+++ b/sources/engine/Stride.VirtualReality/OpenXR/OpenXRHmd.cs
@@ -675,7 +675,6 @@ namespace Stride.VirtualReality
                 nextCompositionLayer += 1;
                 fixed (CompositionLayerBaseHeader** compositionLayersPtr = &compositionLayers[0])
                 {
-                    var projectionLayerPtr = (CompositionLayerBaseHeader*)&projectionLayer;
                     var frameEndInfo = new FrameEndInfo()
                     {
                         Type = StructureType.TypeFrameEndInfo,


### PR DESCRIPTION

# PR Details

This allows to pass a composition layer that will be sent on commit.

Used with see through extensions among others.

By now it only supports one composition layer but should be straight forward to extend to more.

## Related Issue

[#2070](https://github.com/stride3d/stride/issues/2070)

## Motivation and Context

It allows to show camera ouput with a scene overlaid among other use cases of composition layers

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
